### PR TITLE
Inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ o-syntax-highlight uses the following colours, on a light grey background (#f2f2
 
 Color | Hex | Ratio | 14px+ | 18px+  or 14px **bold**
 ---|---|---|---|---
+`black-crimson-25` | `#a50f2d` | [6.93](http://contrast-ratio.com/#%23a50f2d-on-%23f2f2f2) | AA | AAA
+`black-lemon-55` | `#736a0c` | [4.94](http://contrast-ratio.com/#%23736a0c-on-%23f2f2f2) | AA | AAA
 `black-mandarin-35` | `#a65821` | [4.64](http://contrast-ratio.com/#%23a65821-on-%23f2f2f2) | AA | AAA
-`black-crimson-35` | `#a50f2d` | [6.93](http://contrast-ratio.com/#%23a50f2d-on-%23f2f2f2) | AA | AAA
 `claret-lemon-75` | `#b34634` | [4.88](http://contrast-ratio.com/#%23b34634-on-%23f2f2f2) | AA | AAA
 `grey-55` | `#737373` | [4.23](http://contrast-ratio.com/#%23737373-on-%23f2f2f2) | AA | AAA
 `grey-70` | `#4d4d4d` | [7.55](http://contrast-ratio.com/#%234d4d4d-on-%23f2f2f2) | AAA | AAA

--- a/demos/src/html.mustache
+++ b/demos/src/html.mustache
@@ -1,13 +1,11 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
 	<h2>Highlighted Syntax Demos</h2>
 	<h4>HTML</h4>
-		<pre>
-			<code class="o-syntax-highlight--html">
+		<pre><code class="o-syntax-highlight--html">
 <div class="some-class" data-attribute="value">
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.</p>
 	<p>Nam faucibus feugiat lectus, <a href="#">sit amet blandit</a> purus bibendum et.</p>
 	<button type="button" name="button">Button.</button>
 	<!-- <span>Comment</span> -->
-</div></code>
-		</pre>
+</div></code></pre>
 </div>

--- a/demos/src/inline-syntax.mustache
+++ b/demos/src/inline-syntax.mustache
@@ -1,6 +1,8 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
 	<h2>Highlighted Syntax Demos</h2>
 	<h4>HTML</h4>
+
+	<p>This is some text, and it is here to illustrate that if you use a <code>&lt;code></code> tag, it will get light treatment regardless of what language is inside it. But only if it is an inline <code>&lt;code></code> block</p>
 		<pre>
 			<code class="o-syntax-highlight--html">
 <div class="some-class" data-attribute="value">

--- a/origami.json
+++ b/origami.json
@@ -57,6 +57,12 @@
 			"name": "css",
 			"template": "demos/src/css.mustache",
 			"description": "Syntax highlight for CSS"
+		},
+		{
+			"title": "Inline Code",
+			"name": "inline-syntax",
+			"template": "demos/src/inline-syntax.mustache",
+			"description": "Syntax highlight for Inline Code Tags"
 		}
 	]
 }

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -78,6 +78,7 @@ class SyntaxHighlight {
 			}
 		});
 		/* eslint-enable array-callback-return */
+
 		codeBlocks.forEach(this._tokeniseBlock.bind(this));
 	}
 
@@ -87,7 +88,7 @@ class SyntaxHighlight {
  */
 	_tokeniseBlock (element) {
 		this._getLanguage(element);
-		this.opts.syntaxString = (this.opts.language == 'html' ? element.innerHTML : element.innerText);
+		this.opts.syntaxString = (this.opts.language === 'html' ? element.innerHTML : element.innerText);
 		element.innerHTML = this.tokenise();
 	}
 

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -87,7 +87,7 @@ class SyntaxHighlight {
  */
 	_tokeniseBlock (element) {
 		this._getLanguage(element);
-		this.opts.syntaxString = element.textContent;
+		this.opts.syntaxString = (this.opts.language == 'html' ? element.innerHTML : element.innerText);
 		element.innerHTML = this.tokenise();
 	}
 

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -9,6 +9,7 @@
 @include oColorsSetColor('velvet-candy-60', oColorsMix(velvet, candy, 60));
 @include oColorsSetColor('oxford-jade-60', oColorsMix(oxford, jade, 60))
 @include oColorsSetColor('oxford-sky-80', oColorsMix(oxford, sky, 80))
-@include oColorsSetColor('black-mandarin-35', oColorsMix(black, mandarin, 35));
 @include oColorsSetColor('black-crimson-25', oColorsMix(black, crimson, 25));
+@include oColorsSetColor('black-lemon-55', oColorsMix(black, lemon, 55));
+@include oColorsSetColor('black-mandarin-35', oColorsMix(black, mandarin, 35));
 @include oColorsSetColor('grey-55', oColorsMix(black, white, 55));

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -13,12 +13,14 @@
 			tab-size: 4;
 			overflow-x: auto;
 
-			code {
-				color: oColorsGetPaletteColor('grey-70');
-				font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
-				font-size: 14px;
-				white-space: inherit;
-			}
+		}
+
+		code {
+			background: oColorsGetPaletteColor('grey-5');
+			color: oColorsGetPaletteColor('grey-70');
+			font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+			font-size: 14px;
+			white-space: inherit;
 		}
 	}
 }

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -8,7 +8,7 @@
 	[data-o-component='o-syntax-highlight'] {
 		pre {
 			background: oColorsGetPaletteColor('grey-5');
-			padding: 15px;
+			padding: 0 1rem;
 			word-break: break-all;
 			tab-size: 4;
 			overflow-x: auto;

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -13,6 +13,9 @@
 			tab-size: 4;
 			overflow-x: auto;
 
+			code {
+				padding: 0;
+			}
 		}
 
 		code {
@@ -21,6 +24,7 @@
 			font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 			font-size: 14px;
 			white-space: inherit;
+			padding: 0 4px;
 		}
 	}
 }


### PR DESCRIPTION
Highlighted html was requiring `&lt;` to be in the code block, so that's been changed.
A colour (black-lemon-55) was missing, so that's been added.
And the styling has been changed to handle inline `<code>` tags.