### PR TITLE
swap back because reading declared html into the tokenisation is real…

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ It is worth pointing out that the wrapper can hold any html elements. So long as
 </div>
 ```
 
+However, when highlighting `HTML`, there is a caveat.
+Because of the way in which the `<code>` tag works, if you want to highlight markup **which has already been declared**, you will have to replace and `<` with `&lt;` in order for the markup to be read as a string instead of actual HTML.
+
+For example:
+```
+<pre>
+	<code class="o-syntax-highlight--html">
+&lt;html>
+	&lt;head>
+		&lt;!-- links and scripts -->
+	&lt;/head>
+	&lt;body>
+		&lt;div class="some-class"&lt;/div>
+	&lt;/body>
+&lt;/html></code>
+</pre>
+```
+
 ### JavaScript
 
 No code will run automatically unless you are using the Build Service.

--- a/demos/src/inline-syntax.mustache
+++ b/demos/src/inline-syntax.mustache
@@ -5,11 +5,19 @@
 	<p>This is some text, and it is here to illustrate that if you use a <code>&lt;code></code> tag, it will get light treatment regardless of what language is inside it. But only if it is an inline <code>&lt;code></code> block</p>
 		<pre>
 			<code class="o-syntax-highlight--html">
-<div class="some-class" data-attribute="value">
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.</p>
-	<p>Nam faucibus feugiat lectus, <a href="#">sit amet blandit</a> purus bibendum et.</p>
-	<button type="button" name="button">Button.</button>
-	<!-- <span>Comment</span> -->
-</div></code>
+&lt;html>
+	&lt;head>
+		&lt;!-- links and scripts -->
+	&lt;/head>
+	&lt;body>
+		&lt;div class="some-class" data-attribute="value">
+			&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.&lt;/p>
+			&lt;p>Nam faucibus feugiat lectus, &lt;a href="#">sit amet blandit&lt;/a> purus bibendum et.&lt;/p>
+			&lt;button type="button" name="button">Button.&lt;/button>
+			&lt;span>Comment&lt;/span>
+
+		&lt;/div>
+	&lt;/body>
+&lt;/html></code>
 		</pre>
 </div>

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -88,7 +88,7 @@ class SyntaxHighlight {
  */
 	_tokeniseBlock (element) {
 		this._getLanguage(element);
-		this.opts.syntaxString = (this.opts.language === 'html' ? element.innerHTML : element.innerText);
+		this.opts.syntaxString = element.innerText;
 		element.innerHTML = this.tokenise();
 	}
 


### PR DESCRIPTION
…ly complicated/not possible

This only applies to declared markup. It is annoying, but if `<html>` or `<head>` or `<body>` are used, they will be included in the documents' flow. 