### PR TITLE
update demos/line height

### DIFF
--- a/demos/src/css.mustache
+++ b/demos/src/css.mustache
@@ -1,5 +1,4 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
-	<h4>CSS</h4>
 	<pre>
 		<code class='o-syntax-highlight--css'>
 @import 'file'; // using a relative path

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,11 +2,6 @@
 
 @include oSyntaxHighlightAll();
 
-h2,
-h4 {
-	margin-left: 20px;
-}
-
 .demo {
 	margin: 0 auto;
 	width: 750px;

--- a/demos/src/html.mustache
+++ b/demos/src/html.mustache
@@ -1,6 +1,4 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
-	<h2>Highlighted Syntax Demos</h2>
-	<h4>HTML</h4>
 		<pre><code class="o-syntax-highlight--html">
 &lt;div class="some-class" data-attribute="value">
 	&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.&lt;/p>

--- a/demos/src/html.mustache
+++ b/demos/src/html.mustache
@@ -2,10 +2,10 @@
 	<h2>Highlighted Syntax Demos</h2>
 	<h4>HTML</h4>
 		<pre><code class="o-syntax-highlight--html">
-<div class="some-class" data-attribute="value">
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.</p>
-	<p>Nam faucibus feugiat lectus, <a href="#">sit amet blandit</a> purus bibendum et.</p>
-	<button type="button" name="button">Button.</button>
-	<!-- <span>Comment</span> -->
-</div></code></pre>
+&lt;div class="some-class" data-attribute="value">
+	&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque consectetur est in urna iaculis tempus.&lt;/p>
+	&lt;p>Nam faucibus feugiat lectus, &lt;a href="#">sit amet blandit&lt;/a> purus bibendum et.&lt;/p>
+	&lt;button type="button" name="button">Button.&lt;/button>
+	&lt;!-- &lt;span>Comment&lt;/span> -->
+&lt;/div></code></pre>
 </div>

--- a/demos/src/inline-syntax.mustache
+++ b/demos/src/inline-syntax.mustache
@@ -1,7 +1,4 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
-	<h2>Highlighted Syntax Demos</h2>
-	<h4>HTML</h4>
-
 	<p>This is some text, and it is here to illustrate that if you use a <code>&lt;code></code> tag, it will get light treatment regardless of what language is inside it. But only if it is an inline <code>&lt;code></code> block</p>
 		<pre>
 			<code class="o-syntax-highlight--html">

--- a/demos/src/scss.mustache
+++ b/demos/src/scss.mustache
@@ -1,5 +1,4 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
-	<h4>SCSS/SASS</h4>
 	<pre>
 		<code class='o-syntax-highlight--scss'>
 @import: 'file';

--- a/origami.json
+++ b/origami.json
@@ -21,14 +21,6 @@
 	},
 	"demos": [
 		{
-			"title": "imperative",
-			"name": "imperative",
-			"template": "demos/src/imperative.mustache",
-			"js": "demos/src/imperative.js",
-			"description": "Syntax highlight for imperative",
-			"hidden": true
-		},
-		{
 			"title": "HTML",
 			"name": "html",
 			"template": "demos/src/html.mustache",
@@ -39,6 +31,18 @@
 			"name": "js",
 			"template": "demos/src/js.mustache",
 			"description": "Syntax highlight for JS"
+		},
+		{
+			"title": "CSS",
+			"name": "css",
+			"template": "demos/src/css.mustache",
+			"description": "Syntax highlight for CSS"
+		},
+		{
+			"title": "Inline Code",
+			"name": "inline-syntax",
+			"template": "demos/src/inline-syntax.mustache",
+			"description": "Syntax highlight for Inline Code Tags"
 		},
 		{
 			"title": "JSON",
@@ -55,16 +59,12 @@
 			"hidden": true
 		},
 		{
-			"title": "CSS",
-			"name": "css",
-			"template": "demos/src/css.mustache",
-			"description": "Syntax highlight for CSS"
-		},
-		{
-			"title": "Inline Code",
-			"name": "inline-syntax",
-			"template": "demos/src/inline-syntax.mustache",
-			"description": "Syntax highlight for Inline Code Tags"
+			"title": "imperative",
+			"name": "imperative",
+			"template": "demos/src/imperative.mustache",
+			"js": "demos/src/imperative.js",
+			"description": "Syntax highlight for imperative",
+			"hidden": true
 		}
 	]
 }

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -23,6 +23,7 @@
 			color: oColorsGetPaletteColor('grey-70');
 			font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 			font-size: 14px;
+			line-height: 1.5;
 			white-space: inherit;
 			padding: 0 4px;
 		}


### PR DESCRIPTION
If `o-syntax-highlight` is included in another component that has an explicit line-height (e.g. [`o-layout`](https://github.com/Financial-Times/o-layout/)) its line height will be overriden, so we are setting it explicitly here, where we have more specificity.