### PR TITLE
Update padding.

### DIFF
--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -8,14 +8,10 @@
 	[data-o-component='o-syntax-highlight'] {
 		pre {
 			background: oColorsGetPaletteColor('grey-5');
-			padding: 0 1rem;
+			padding: 1rem;
 			word-break: break-all;
 			tab-size: 4;
 			overflow-x: auto;
-
-			code {
-				padding: 0;
-			}
 		}
 
 		code {
@@ -25,7 +21,6 @@
 			font-size: 14px;
 			line-height: 1.5;
 			white-space: inherit;
-			padding: 0 4px;
 		}
 	}
 }


### PR DESCRIPTION
Adds extra padding to `o-syntax-highlight` by default. 

The usecase I have in mind changes from:
<img width="619" alt="screen shot 2018-07-30 at 16 20 14" src="https://user-images.githubusercontent.com/10405691/43406608-8a3891c8-9414-11e8-8e69-7121186b342f.png">

To:
<img width="632" alt="screen shot 2018-07-30 at 16 21 28" src="https://user-images.githubusercontent.com/10405691/43406679-ad803096-9414-11e8-9c96-f0e4651ac4f4.png">

This will effect dependents like the registry-ui. Are we happy with that?
Current:
<img width="627" alt="screen shot 2018-07-30 at 16 17 35" src="https://user-images.githubusercontent.com/10405691/43406718-c1ee5cba-9414-11e8-8fbc-f6a06c6a1732.png">

After:
<img width="630" alt="screen shot 2018-07-30 at 16 18 53" src="https://user-images.githubusercontent.com/10405691/43406730-c6bb7d22-9414-11e8-8e95-036169d908f9.png">
