### PR TITLE
Add diff language, remove Prism global, load SASS/JSON languages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-node_modules/
-bower_components/
-demos/local
+.DS_Store
+.env
+/.sass-cache/
+/bower_components/
+/node_modules/
+/build/
+.idea/
+/demos/local
+/coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# o-syntax-highlight [![Circle CI](https://circleci.com/gh/Financial-Times/o-syntax-highlight/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/o-syntax-highlight/tree/master)  
+# o-syntax-highlight [![Circle CI](https://circleci.com/gh/Financial-Times/o-syntax-highlight/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/o-syntax-highlight/tree/master)
 
 A syntax highlighter for Origami-supported documentation that wraps [PrismJs](https://github.com/PrismJS/prism).
 
@@ -64,6 +64,8 @@ The same is true for all other available languages:
 - HTML: `o-syntax-highlight--html`
 - CSS: `o-syntax-highlight--css`
 - SCSS/SASS: `o-syntax-highlight--scss` _or_ `o-syntax-highlight--sass`
+- JSON: `o-syntax-highlight--json`
+- DIFF: `o-syntax-highlight--diff`
 
 It is worth pointing out that the wrapper can hold any html elements. So long as all of the code blocks within the wrapper are written as described above, o-syntax-highlight will ignore everything else.
 ```html
@@ -136,6 +138,8 @@ The same is applicable for the other languages:
 - HTML: `oSyntaxHighlightHTML()`
 - CSS: `oSyntaxHighlightCSS()`
 - SCSS/SASS: `oSyntaxHighlightSCSS()`
+- JSON: `oSyntaxHighlightJSON()`
+- DIFF: `oSyntaxHighlightDIFF()`
 
 ---
 

--- a/demos/src/diff.mustache
+++ b/demos/src/diff.mustache
@@ -1,0 +1,26 @@
+<div class="demo" data-o-component='o-syntax-highlight'>
+<h4>DIFF</h4>
+<pre><code class='o-syntax-highlight--diff'>
+&lt;div class="o-example o-example--alert o-example--error" data-o-component="o-example">
+	&lt;div class="o-example__container">
+		&lt;div class="o-example__content">
+-			&lt;p class="o-example__highlight">Something went wrong!
++			&lt;p class="o-example__content-main">
++				&lt;span class="o-example__content-highlight">Something went wrong!&lt;/span>
+-				&lt;span class="o-example__detail">The quick brown fox did not jump over the lazy dogs.&lt;/span>
++				&lt;span class="o-example__content-detail">The quick brown fox did not jump over the lazy dogs.&lt;/span>
+			&lt;/p>
++			&lt;p class="o-example__additional-info">Did you know that that sentence uses all of the letters in the alphabet at least once?&lt;/p>
+-			&lt;p class="o-example__content-additional">Did you know that that sentence uses all of the letters in the alphabet at least once?&lt;/p>
+
+			&lt;div class="o-example__actions">
+-				&lt;a href="#" class="o-example__action--primary">Button&lt;/a>
++				&lt;a href="#" class="o-example__actions__primary">Button&lt;/a>
+-				&lt;a href="#" class="o-example__action--secondary">Text link&lt;/a>
++				&lt;a href="#" class="o-example__actions__secondary">Text link&lt;/a>
+			&lt;/div>
+		&lt;/div>
+	&lt;/div>
+&lt;/div>
+</code></pre>
+</div>

--- a/demos/src/json.mustache
+++ b/demos/src/json.mustache
@@ -9,7 +9,7 @@
 		"names"
 	],
 	"object" : {
-		"nested": "<div>html</div>"
+		"nested": "&lt;div>html&lt;/div>"
 	}
 	"numbers": 1
 }</code>

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,8 @@
 @import 'o-colors/main';
 
-@import 'src/scss/main';
+@import 'src/scss/variables';
+@import 'src/scss/colors';
+@import 'src/scss/languages/main';
 
 @if $o-syntax-highlight-is-silent == false {
 	@include oSyntaxHighlightAll();

--- a/origami.json
+++ b/origami.json
@@ -48,15 +48,19 @@
 			"title": "JSON",
 			"name": "json",
 			"template": "demos/src/json.mustache",
-			"description": "Syntax highlight for JSON",
-			"hidden": true
+			"description": "Syntax highlight for JSON"
 		},
 		{
 			"title": "SCSS",
 			"name": "scss",
 			"template": "demos/src/scss.mustache",
-			"description": "Syntax highlight for SCSS",
-			"hidden": true
+			"description": "Syntax highlight for SCSS"
+		},
+		{
+			"title": "Diff",
+			"name": "diff",
+			"template": "demos/src/diff.mustache",
+			"description": "Syntax highlight for diff"
 		},
 		{
 			"title": "imperative",

--- a/src/js/languages/prism-diff.js
+++ b/src/js/languages/prism-diff.js
@@ -1,0 +1,23 @@
+// Removes support for ">/< styles" so non-indented HTML shows correctly in the diff.
+// Prism creates a global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
+// @see https://github.com/PrismJS/prism/blob/v1.15.0/components/prism-diff.js#L11
+Prism.languages.diff = {
+    'coord': [
+        // Match all kinds of coord lines (prefixed by "+++", "---" or "***").
+        /^(?:\*{3}|-{3}|\+{3}).*$/m,
+        // Match "@@ ... @@" coord lines in unified diff.
+        /^@@.*@@$/m,
+        // Match coord lines in normal diff (starts with a number).
+        /^\d+.*$/m
+    ],
+
+    // Match inserted and deleted lines. Support both +/- and >/< styles.
+    'deleted': /^[-].*$/m,
+    'inserted': /^[+].*$/m,
+
+    // Match "different" lines (prefixed with "!") in context diff.
+    'diff': {
+        'pattern': /^!(?!!).+$/m,
+        'alias': 'important'
+    }
+};

--- a/src/js/languages/prism-diff.js
+++ b/src/js/languages/prism-diff.js
@@ -1,23 +1,22 @@
 // Removes support for ">/< styles" so non-indented HTML shows correctly in the diff.
-// Prism creates a global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
 // @see https://github.com/PrismJS/prism/blob/v1.15.0/components/prism-diff.js#L11
-Prism.languages.diff = {
-    'coord': [
-        // Match all kinds of coord lines (prefixed by "+++", "---" or "***").
-        /^(?:\*{3}|-{3}|\+{3}).*$/m,
-        // Match "@@ ... @@" coord lines in unified diff.
-        /^@@.*@@$/m,
-        // Match coord lines in normal diff (starts with a number).
-        /^\d+.*$/m
-    ],
+export default {
+	'coord': [
+		// Match all kinds of coord lines (prefixed by "+++", "---" or "***").
+		/^(?:\*{3}|-{3}|\+{3}).*$/m,
+		// Match "@@ ... @@" coord lines in unified diff.
+		/^@@.*@@$/m,
+		// Match coord lines in normal diff (starts with a number).
+		/^\d+.*$/m
+	],
 
-    // Match inserted and deleted lines. Support both +/- and >/< styles.
-    'deleted': /^[-].*$/m,
-    'inserted': /^[+].*$/m,
+	// Match inserted and deleted lines. Support both +/- and >/< styles.
+	'deleted': /^[-].*$/m,
+	'inserted': /^[+].*$/m,
 
-    // Match "different" lines (prefixed with "!") in context diff.
-    'diff': {
-        'pattern': /^!(?!!).+$/m,
-        'alias': 'important'
-    }
+	// Match "different" lines (prefixed with "!") in context diff.
+	'diff': {
+		'pattern': /^!(?!!).+$/m,
+		'alias': 'important'
+	}
 };

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -3,6 +3,7 @@ import throwError from './helpers';
 import prism from 'prism/prism.js';
 import diff from './languages/prism-diff.js';
 import loadLanguages from 'prism/components/index.js';
+// Adds to Prism global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
 require('prism/components/prism-json.js');
 require('prism/components/prism-scss.js');
 require('prism/components/prism-css.js');
@@ -15,7 +16,7 @@ class SyntaxHighlight {
 	 * @param {String} options.language - The language to tokenise the code for
 	 */
 	constructor (syntaxEl, options) {
-		delete window.Prism; // Prism creates a global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
+		delete window.Prism; // Remove Prism global https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
 		prism.languages.diff = diff; // Assign custom diff language
 		this.syntaxElement = syntaxEl;
 		this.opts = Object.assign({

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -2,6 +2,10 @@ import throwError from './helpers';
 
 import prism from 'prism/prism.js';
 import loadLanguages from 'prism/components/index.js';
+require('prism/components/prism-json.js');
+require('prism/components/prism-scss.js');
+require('prism/components/prism-css.js');
+require('./languages/prism-diff.js');
 
 class SyntaxHighlight {
 	/**
@@ -11,6 +15,7 @@ class SyntaxHighlight {
 	 * @param {String} options.language - The language to tokenise the code for
 	 */
 	constructor (syntaxEl, options) {
+		delete window.Prism;
 		this.syntaxElement = syntaxEl;
 		this.opts = Object.assign({
 			language: '',

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -1,11 +1,11 @@
 import throwError from './helpers';
 
 import prism from 'prism/prism.js';
+import diff from './languages/prism-diff.js';
 import loadLanguages from 'prism/components/index.js';
 require('prism/components/prism-json.js');
 require('prism/components/prism-scss.js');
 require('prism/components/prism-css.js');
-require('./languages/prism-diff.js');
 
 class SyntaxHighlight {
 	/**
@@ -15,7 +15,8 @@ class SyntaxHighlight {
 	 * @param {String} options.language - The language to tokenise the code for
 	 */
 	constructor (syntaxEl, options) {
-		delete window.Prism;
+		delete window.Prism; // Prism creates a global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
+		prism.languages.diff = diff; // Assign custom diff language
 		this.syntaxElement = syntaxEl;
 		this.opts = Object.assign({
 			language: '',

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -7,8 +7,8 @@
 // oColorsGetPaletteColor(oxford); listed here for reference only
 @include oColorsSetColor('claret-lemon-75', oColorsMix(claret, lemon, 75));
 @include oColorsSetColor('velvet-candy-60', oColorsMix(velvet, candy, 60));
-@include oColorsSetColor('oxford-jade-60', oColorsMix(oxford, jade, 60))
-@include oColorsSetColor('oxford-sky-80', oColorsMix(oxford, sky, 80))
+@include oColorsSetColor('oxford-jade-60', oColorsMix(oxford, jade, 60));
+@include oColorsSetColor('oxford-sky-80', oColorsMix(oxford, sky, 80));
 @include oColorsSetColor('black-crimson-25', oColorsMix(black, crimson, 25));
 @include oColorsSetColor('black-lemon-55', oColorsMix(black, lemon, 55));
 @include oColorsSetColor('black-mandarin-35', oColorsMix(black, mandarin, 35));

--- a/src/scss/languages/_diff.scss
+++ b/src/scss/languages/_diff.scss
@@ -1,0 +1,12 @@
+@mixin oSyntaxHighlightDIFF {
+	.o-syntax-highlight--diff {
+        .token.deleted {
+            color: oColorsMix(black, crimson, 75);
+            background-color: oColorsMix(crimson, grey-5, 40);
+        }
+        .token.inserted {
+            color: oColorsMix(black, wasabi, 75);
+            background-color: oColorsMix(wasabi, grey-5, 40);
+        }
+	}
+}

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -3,6 +3,7 @@
 @import 'js';
 @import 'json';
 @import 'scss';
+@import 'diff';
 
 @mixin oSyntaxHighlightBase() {
 	[data-o-component='o-syntax-highlight'] {
@@ -32,4 +33,5 @@
 	@include oSyntaxHighlightJS();
 	@include oSyntaxHighlightJSON();
 	@include oSyntaxHighlightSCSS();
+	@include oSyntaxHighlightDIFF();
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,4 +1,0 @@
-@import 'variables';
-@import 'colors';
-
-@import 'languages/main';


### PR DESCRIPTION
**Removes Prism from window after init.**
- Prism [adds itself](https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6) to `window`. I'm not sure it's possible to avoid, but with this PR the global is deleted on init. As an undocumented bug of a relatively new component I don't think this should be considered a breaking change, although open to debate.

**Adds diff language support.**
New colours have been added  to support this look; they pass WCAG AAA at a normal text size. I opted not to expose the colours as a usecase with the assumption  we don't want them to be reused outside a diff context.
<img width="768" alt="screen shot 2018-08-06 at 13 38 34" src="https://user-images.githubusercontent.com/10405691/43717895-e5353af6-9980-11e8-9a1d-77594f89b11f.png">

**Loads JSON and SASS languages by default.**
 Production build, no compression:
- JS: 27K -> 29K
- CSS: 4.2K -> 4.4K