### PR TITLE
update bg colours to match internal brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ A syntax highlighter for Origami-supported documentation that wraps [PrismJs](ht
 This component provides accessible syntax highlighting for Javascript, JSON, HTML, CSS, Sass and SCSS.
 _If there are any languages you would like to highlight that we don't currently support, please open an issue and we will provide it._
 
-o-syntax-highlight uses the following colours, on a light grey background (#f2f2f2). It is compliant with the contrast for [WCAG AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html). In order to meet the criteria for AAA at 14px+, the colours would be far too dark to distinguish syntax highlighting effectively.
+o-syntax-highlight uses the following colours, on a `slate-white-5` background (`#f4f4f5`). It is compliant with the contrast for [WCAG AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html). In order to meet the criteria for AAA at 14px+, the colours would be far too dark to distinguish syntax highlighting effectively.
 
 Color | Hex | Ratio | 14px+ | 18px+  or 14px **bold**
 ---|---|---|---|---
-`black-crimson-25` | `#a50f2d` | [6.93](http://contrast-ratio.com/#%23a50f2d-on-%23f2f2f2) | AA | AAA
-`black-lemon-55` | `#736a0c` | [4.94](http://contrast-ratio.com/#%23736a0c-on-%23f2f2f2) | AA | AAA
-`black-mandarin-35` | `#a65821` | [4.64](http://contrast-ratio.com/#%23a65821-on-%23f2f2f2) | AA | AAA
-`claret-lemon-75` | `#b34634` | [4.88](http://contrast-ratio.com/#%23b34634-on-%23f2f2f2) | AA | AAA
-`grey-55` | `#737373` | [4.23](http://contrast-ratio.com/#%23737373-on-%23f2f2f2) | AA | AAA
-`grey-70` | `#4d4d4d` | [7.55](http://contrast-ratio.com/#%234d4d4d-on-%23f2f2f2) | AAA | AAA
-`oxford` | `#0f5499` | [6.82](http://contrast-ratio.com/#%230f5499-on-%23f2f2f2) | AA | AAA
-`oxford-jade-60` | `#097a7f` | [4.57](http://contrast-ratio.com/#%23097a7f-on-%23f2f2f2) | AA | AAA
-`oxford-sky-80` | `#3571ad` | [4.55](http://contrast-ratio.com/#%233571ad-on-%23f2f2f2) | AA | AAA
-`velvet-candy-60` | `#9b5191` | [4.71](http://contrast-ratio.com/#%239b5191-on-%23f2f2f2) | AA | AAA
+`black-crimson-25` | `#a50f2d` | [7.06](https://contrast-ratio.com/#%23a50f2d-on-%23f4f4f5) | AAA | AAA
+`black-lemon-55` | `#736a0c` | [5.03](https://contrast-ratio.com/#%23736a0c-on-%23f4f4f5) | AA | AAA
+`black-mandarin-35` | `#a65821` | [4.72](https://contrast-ratio.com/#%23a65821-on-%23f4f4f5) | AA | AAA
+`claret-lemon-75` | `#b34634` | [4.97](http://contrast-ratio.com/#%23b34634-on-%23f4f4f5) | AA | AAA
+`grey-55` | `#737373` | [4.31](http://contrast-ratio.com/#%23737373-on-%23f4f4f5) | AA | AAA
+`grey-70` | `#4d4d4d` | [7.69](http://contrast-ratio.com/#%234d4d4d-on-%23f4f4f5) | AAA | AAA
+`oxford` | `#0f5499` | [6.95](http://contrast-ratio.com/#%230f5499-on-%23f4f4f5) | AA | AAA
+`oxford-jade-60` | `#097a7f` | [4.65](http://contrast-ratio.com/#%23097a7f-on-%23f4f4f5) | AA | AAA
+`oxford-sky-80` | `#3571ad` | [4.64](http://contrast-ratio.com/#%233571ad-on-%23f4f4f5) | AA | AAA
+`velvet-candy-60` | `#9b5191` | [4.8](http://contrast-ratio.com/#%239b5191-on-%23f4f4f5) | AA | AAA
 
 ### Markup
 

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -1,5 +1,3 @@
-@include oColorsSetColor('grey-5', oColorsMix(black, white, 5)); //background
-
 // passes AAA for any size text
 @include oColorsSetColor('grey-70', oColorsMix(black, white, 70));
 @include oColorsSetColor('black-crimson-25', oColorsMix(black, crimson, 25));

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -2,6 +2,7 @@
 
 // passes AAA for any size text
 @include oColorsSetColor('grey-70', oColorsMix(black, white, 70));
+@include oColorsSetColor('black-crimson-25', oColorsMix(black, crimson, 25));
 
 // Passes AA for any, AAA for 18pt or bold above 14px
 // oColorsGetPaletteColor(oxford); listed here for reference only
@@ -9,7 +10,6 @@
 @include oColorsSetColor('velvet-candy-60', oColorsMix(velvet, candy, 60));
 @include oColorsSetColor('oxford-jade-60', oColorsMix(oxford, jade, 60));
 @include oColorsSetColor('oxford-sky-80', oColorsMix(oxford, sky, 80));
-@include oColorsSetColor('black-crimson-25', oColorsMix(black, crimson, 25));
 @include oColorsSetColor('black-lemon-55', oColorsMix(black, lemon, 55));
 @include oColorsSetColor('black-mandarin-35', oColorsMix(black, mandarin, 35));
 @include oColorsSetColor('grey-55', oColorsMix(black, white, 55));

--- a/src/scss/languages/_diff.scss
+++ b/src/scss/languages/_diff.scss
@@ -1,12 +1,12 @@
 @mixin oSyntaxHighlightDIFF {
 	.o-syntax-highlight--diff {
         .token.deleted {
-            color: oColorsMix(black, crimson, 75);
-            background-color: oColorsMix(crimson, grey-5, 40);
+            color: oColorsMix('black', 'crimson', 75);
+            background-color: oColorsMix('crimson', 'slate-white-5', 40);
         }
         .token.inserted {
-            color: oColorsMix(black, wasabi, 75);
-            background-color: oColorsMix(wasabi, grey-5, 40);
+            color: oColorsMix('black', 'wasabi', 75);
+            background-color: oColorsMix('wasabi', 'slate-white-5', 40);
         }
 	}
 }

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -8,7 +8,7 @@
 @mixin oSyntaxHighlightBase() {
 	[data-o-component='o-syntax-highlight'] {
 		pre {
-			background: oColorsGetPaletteColor('grey-5');
+			background: oColorsGetPaletteColor('slate-white-5');
 			padding: 1rem;
 			word-break: break-all;
 			tab-size: 4;
@@ -16,7 +16,7 @@
 		}
 
 		code {
-			background: oColorsGetPaletteColor('grey-5');
+			background: oColorsGetPaletteColor('slate-white-5');
 			color: oColorsGetPaletteColor('grey-70');
 			font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 			font-size: 14px;


### PR DESCRIPTION
A slight issue was raised where, if ever a `<code>` is used on an internal branded background, there was a slight dissonance, so changing everything to `slate-white-5` to avoid that. Bonus: it improves contrast a bit! 💪 