### PR TITLE
use import syntax to do a side-effectful import

### DIFF
--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -3,9 +3,9 @@ import throwError from './helpers';
 import prism from 'prism/prism.js';
 import diff from './languages/prism-diff.js';
 // Adds to Prism global object which we remove https://github.com/PrismJS/prism/blob/v1.15.0/prism.js#L6
-require('prism/components/prism-bash.js');
-require('prism/components/prism-json.js');
-require('prism/components/prism-scss.js');
+import 'prism/components/prism-bash.js';
+import 'prism/components/prism-json.js';
+import 'prism/components/prism-scss.js';
 
 class SyntaxHighlight {
 	/**


### PR DESCRIPTION
We were using the `require` function to load a JS file for it's side-effect (loading extra features into Prism). It is possible to do this with an `import` statement, which makes our component use only JavaScript that is valid in web-browsers (`require` is not in browsers and never will be, whereas `import` is in browsers).