### PR TITLE
fix: remove padding from code elements inside of pre elements

### DIFF
--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -24,6 +24,10 @@
 			font-size: 14px;
 			line-height: 1.5;
 			white-space: inherit;
+		}
+
+		:not(pre) > code,
+		:not(pre) > var {
 			padding: 0.2em 0.3em; //for inline <code> tags
 		}
 


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/51677/58170644-dbb6cf00-7c8b-11e9-837f-5aec58c80713.png)

**After** _I think..._

![image](https://user-images.githubusercontent.com/51677/58170662-ea9d8180-7c8b-11e9-8b61-6c9f8e34039c.png)
