### PR TITLE
V2: Primary Mixin

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,29 @@
+## Migration Guide
+
+### Migrating from v1 to v2
+
+This major introduces the primary mixin, and enables branding for 'master' and 'internal' brands.
+The main change is how to output syntax-specific styling:
+
+```diff
+- oSyntaxHighlightBase()
+- oSyntaxHighlightBASH()
+- oSyntaxHighlightCSS()
+- oSyntaxHighlightDIFF()
+- oSyntaxHighlightHTML()
+- oSyntaxHighlightJS()
+- oSyntaxHighlightJSON()
+- oSyntaxHighlightSCSS()
++ oSyntaxHighlight()
+```
+
+The primary mixin requires an `$opts` parameter that accepts a 'languages' list. That list can contains any or all of the following:
+- 'bash'
+- 'css'
+- 'diff'
+- 'html'
+- 'js' or 'javascript'
+- 'json'
+- 'scss' or 'sass'
+
+There are no changes to the markup or the JavaScript.

--- a/README.md
+++ b/README.md
@@ -125,29 +125,43 @@ myElement.innerHTML = highlighter.tokenise();
 ```
 
 ### Sass
-As with all Origami components, o-syntax-highlight has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than using its mixins with your own Sass) set `$o-syntax-highlight-is-silent: false;` in your Sass before you import the o-syntax-highlight Sass.
 
-You can't choose your own classnames, but you can choose to load specific language styles as follows:
+You can include highlighting for all languages by calling:
+
 ```scss
-	@include oSyntaxHighlightBase();
-	@include oSyntaxHighlightJSON();
+@include oSyntaxHighlight();
 ```
 
-The same is applicable for the other languages:
-- Javascript: `oSyntaxHighlightJS()`
-- HTML: `oSyntaxHighlightHTML()`
-- CSS: `oSyntaxHighlightCSS()`
-- SCSS/SASS: `oSyntaxHighlightSCSS()`
-- JSON: `oSyntaxHighlightJSON()`
-- DIFF: `oSyntaxHighlightDIFF()`
+You can also be more specific about which languages you would like styling output for by using an `$opts` map:
+```scss
+	@include oSyntaxHighlight($opts: (
+		'languages': (
+			'html', 
+			'json'
+		)
+	));
+```
+`o-syntax-highlight` accespts the following options:
+- 'bash'
+- 'css'
+- 'diff'
+- 'html'
+- 'js' or 'javascript'
+- 'json'
+- 'scss' or 'sass'
 
----
+
+## Migration
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+⚠ maintained | 1 | 1.6.4 | N/A |
 
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-syntax-highlight/issues), visit [#ft-origami](https://financialtimes.slack.com/messages/ft-origami/) or email [Origami Support](mailto:origami-support@ft.com).
 
-----
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A syntax highlighter for Origami-supported documentation that wraps [PrismJs](ht
 
 ## Usage
 
-This component provides accessible syntax highlighting for Javascript, JSON, HTML, CSS, Sass and SCSS.
+This component provides accessible syntax highlighting for `bash`, `diff`, Javascript, JSON, HTML, CSS and Sass/SCSS.
 _If there are any languages you would like to highlight that we don't currently support, please open an issue and we will provide it._
 
 o-syntax-highlight uses the following colours, on a `grey-5` background (`#f2f2f2`). It is compliant with the contrast for [WCAG AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html). In order to meet the criteria for AAA at 14px+, the colours would be far too dark to distinguish syntax highlighting effectively.
@@ -146,9 +146,9 @@ You can also be more specific about which languages you would like styling outpu
 - 'css'
 - 'diff'
 - 'html'
-- 'js' or 'javascript'
+- 'js' _or_ 'javascript'
 - 'json'
-- 'scss' or 'sass'
+- 'scss' _or_ 'sass'
 
 
 ## Migration

--- a/demos/src/bash.mustache
+++ b/demos/src/bash.mustache
@@ -1,6 +1,6 @@
 <div class="demo" data-o-component='o-syntax-highlight'>
 <pre><code class='o-syntax-highlight--bash'>echo $1
-string="I'm a fan of origami."
+string="I'm a fan of Origami."
 echo ${string:6:3}
 
 expr 3 + 12

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,6 +2,7 @@ $o-syntax-highlight-is-silent: false;
 
 @import '../../main';
 
+
 .demo {
 	margin: 0 auto;
 	width: 750px;

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,7 +2,6 @@ $o-syntax-highlight-is-silent: false;
 
 @import '../../main';
 
-
 .demo {
 	margin: 0 auto;
 	width: 750px;

--- a/main.scss
+++ b/main.scss
@@ -12,7 +12,7 @@
 		'html', 
 		'js',
 		'json',
-		'scss'
+		'sass'
 	)
 )) {
 	$languages: map-get($opts, 'languages');
@@ -35,7 +35,7 @@
 		@include _oSyntaxHighlightHTML();
 	}
 
-	@if index($languages, 'js') {
+	@if index($languages, 'js') or index($languages, 'javascript') {
 		@include _oSyntaxHighlightJS();
 	}
 
@@ -43,7 +43,7 @@
 		@include _oSyntaxHighlightJSON();
 	}
 
-	@if index($languages, 'scss') {
+	@if index($languages, 'scss') or index($languages, 'sass') {
 		@include _oSyntaxHighlightSCSS();
 	}
 }

--- a/main.scss
+++ b/main.scss
@@ -4,8 +4,52 @@
 @import 'src/scss/colors';
 @import 'src/scss/languages/main';
 
+@mixin oSyntaxHighlight($opts: (
+	'languages': (
+		'bash',
+		'css',
+		'diff', 
+		'html', 
+		'js',
+		'json',
+		'scss'
+	)
+)) {
+	$languages: map-get($opts, 'languages');
+
+	@include _oSyntaxHighlightBase();
+
+	@if index($languages, 'bash') {
+		@include _oSyntaxHighlightBash();
+	}
+
+	@if index($languages, 'css') {
+		@include _oSyntaxHighlightCSS();
+	}
+
+	@if index($languages, 'diff') {
+		@include _oSyntaxHighlightDiff();
+	}
+
+	@if index($languages, 'html') {
+		@include _oSyntaxHighlightHTML();
+	}
+
+	@if index($languages, 'js') {
+		@include _oSyntaxHighlightJS();
+	}
+
+	@if index($languages, 'json') {
+		@include _oSyntaxHighlightJSON();
+	}
+
+	@if index($languages, 'scss') {
+		@include _oSyntaxHighlightSCSS();
+	}
+}
+
 @if $o-syntax-highlight-is-silent == false {
-	@include oSyntaxHighlightAll();
+	@include oSyntaxHighlight();
 
 	$o-syntax-highlight-is-silent: true !global;
 }

--- a/origami.json
+++ b/origami.json
@@ -4,6 +4,10 @@
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": 1,
+	"brands": [
+		"master",
+		"internal"
+	],
 	"support": "https://github.com/Financial-Times/o-syntax-highlight/issues",
 	"supportContact": {
 		"email": "origami.support@ft.com",

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -1,4 +1,5 @@
 // passes AAA for any size text
+// oColorsGetPaletteColor(teal); listed here for reference only
 @include oColorsSetColor('grey-70', oColorsMix(black, white, 70));
 @include oColorsSetColor('oxford-crimson-50', oColorsMix(oxford, crimson, 50));
 
@@ -10,7 +11,6 @@
 @include oColorsSetColor('crimson-jade-80', oColorsMix(crimson, jade, 80));
 @include oColorsSetColor('grey-60', oColorsMix(black, white, 60));
 @include oColorsSetColor('oxford-jade-60', oColorsMix(oxford, jade, 60));
-@include oColorsSetColor('oxford-sky-80', oColorsMix(oxford, sky, 80));
 @include oColorsSetColor('oxford-lemon-80', oColorsMix(oxford, lemon, 80));
 
 //background

--- a/src/scss/languages/_bash.scss
+++ b/src/scss/languages/_bash.scss
@@ -1,11 +1,8 @@
 @mixin _oSyntaxHighlightBash {
 	.o-syntax-highlight--bash {
 		.token {
-			&.comment { color: oColorsGetPaletteColor('grey-60'); }
 			&.function { color: oColorsGetPaletteColor('oxford-lemon-80'); }
 			&.operator { color: oColorsGetPaletteColor('crimson-jade-80');}
-			&.punctuation { color: oColorsGetPaletteColor('grey-70'); }
-			&.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
 			&.variable { color: oColorsGetPaletteColor('oxford'); }
 		}
 	}

--- a/src/scss/languages/_bash.scss
+++ b/src/scss/languages/_bash.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightBASH {
+@mixin _oSyntaxHighlightBash {
 	.o-syntax-highlight--bash {
 		.token {
 			&.comment { color: oColorsGetPaletteColor('grey-60'); }

--- a/src/scss/languages/_css.scss
+++ b/src/scss/languages/_css.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightCSS {
+@mixin _oSyntaxHighlightCSS {
 	.o-syntax-highlight--css {
 		.token {
 

--- a/src/scss/languages/_css.scss
+++ b/src/scss/languages/_css.scss
@@ -9,12 +9,10 @@
 				.rule { color: oColorsGetPaletteColor('crimson-jade-80'); }
 			}
 
-			&.comment { color: oColorsGetPaletteColor('grey-60'); }
 			&.function { color: oColorsGetPaletteColor('oxford-lemon-80'); }
 			&.important { color:  oColorsGetPaletteColor('oxford-crimson-50'); }
 
-			&.property,
-			&.punctuation {
+			&.property {
 				color: oColorsGetPaletteColor('grey-70');
 			}
 
@@ -22,8 +20,6 @@
 			&.url {
 				color: oColorsGetPaletteColor('oxford');
 			}
-
-			&.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
 		}
 	}
 }

--- a/src/scss/languages/_diff.scss
+++ b/src/scss/languages/_diff.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightDIFF {
+@mixin _oSyntaxHighlightDiff {
 	.o-syntax-highlight--diff {
 		.token.deleted {
 			color: oColorsMix('black', 'crimson', 75);

--- a/src/scss/languages/_html.scss
+++ b/src/scss/languages/_html.scss
@@ -3,9 +3,7 @@
 		.token {
 			&.attr-name { color: oColorsGetPaletteColor('oxford'); }
 			&.attr-value { color: oColorsGetPaletteColor('oxford-jade-60'); }
-			&.tag {
-				color: oColorsGetPaletteColor('crimson-jade-80');
-			}
+			&.tag { color: oColorsGetPaletteColor('crimson-jade-80'); }
 		}
 	}
 }

--- a/src/scss/languages/_html.scss
+++ b/src/scss/languages/_html.scss
@@ -3,10 +3,8 @@
 		.token {
 			&.attr-name { color: oColorsGetPaletteColor('oxford'); }
 			&.attr-value { color: oColorsGetPaletteColor('oxford-jade-60'); }
-			&.comment { color: oColorsGetPaletteColor('grey-60'); }
 			&.tag {
 				color: oColorsGetPaletteColor('crimson-jade-80');
-				.punctuation { color: oColorsGetPaletteColor('grey-70'); }
 			}
 		}
 	}

--- a/src/scss/languages/_html.scss
+++ b/src/scss/languages/_html.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightHTML {
+@mixin _oSyntaxHighlightHTML {
 	.o-syntax-highlight--html {
 		.token {
 			&.attr-name { color: oColorsGetPaletteColor('oxford'); }

--- a/src/scss/languages/_js.scss
+++ b/src/scss/languages/_js.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightJS () {
+@mixin _oSyntaxHighlightJS () {
 	.o-syntax-highlight--js,
 	.o-syntax-highlight--javascript {
 		.token {

--- a/src/scss/languages/_js.scss
+++ b/src/scss/languages/_js.scss
@@ -2,10 +2,6 @@
 	.o-syntax-highlight--js,
 	.o-syntax-highlight--javascript {
 		.token {
-			&.comment { color: oColorsGetPaletteColor('grey-60'); }
-			&.punctuation { color: oColorsGetPaletteColor('grey-70'); }
-			&.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
-
 			&.regex,
 			&.boolean {
 				color: oColorsGetPaletteColor('black-jade-30');

--- a/src/scss/languages/_json.scss
+++ b/src/scss/languages/_json.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightJSON () {
+@mixin _oSyntaxHighlightJSON () {
 	.o-syntax-highlight--json {
 		.token {
 			&.number { color: oColorsGetPaletteColor('crimson-jade-80'); }

--- a/src/scss/languages/_json.scss
+++ b/src/scss/languages/_json.scss
@@ -4,7 +4,6 @@
 			&.number { color: oColorsGetPaletteColor('crimson-jade-80'); }
 			&.operator { color: oColorsGetPaletteColor('grey-70'); }
 			&.property { color: oColorsGetPaletteColor('oxford'); }
-			&.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
 		}
 	}
 }

--- a/src/scss/languages/_scss.scss
+++ b/src/scss/languages/_scss.scss
@@ -1,4 +1,4 @@
-@mixin oSyntaxHighlightSCSS {
+@mixin _oSyntaxHighlightSCSS {
 	.o-syntax-highlight--scss,
 	.o-syntax-highlight--sass {
 		.token {

--- a/src/scss/languages/_scss.scss
+++ b/src/scss/languages/_scss.scss
@@ -7,7 +7,6 @@
 				color: oColorsGetPaletteColor('black-jade-30');
 			}
 
-			&.comment { color: oColorsGetPaletteColor('grey-60'); }
 			&.function { color: oColorsGetPaletteColor('oxford-lemon-80'); }
 			&.keyword { color: oColorsGetPaletteColor('crimson-jade-80'); }
 
@@ -17,12 +16,9 @@
 				color:  oColorsGetPaletteColor('black-crimson-25');
 			}
 
-			&.placeholder {  color: oColorsGetPaletteColor('black-lemon-55'); }
+			&.placeholder { color: oColorsGetPaletteColor('black-lemon-55'); }
 
-			&.property,
-			&.punctuation {
-				color: oColorsGetPaletteColor('grey-70');
-			}
+			&.property { color: oColorsGetPaletteColor('grey-70'); }
 
 			&.selector,
 			&.url {
@@ -33,8 +29,6 @@
 			&.statement.keyword {
 				color: oColorsGetPaletteColor('oxford-crimson-50');
 			}
-
-			&.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
 		}
 	}
 }

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -14,12 +14,16 @@
 			word-break: break-all;
 			tab-size: 4;
 			overflow-x: auto;
+
+			.token.comment { color: oColorsGetPaletteColor('grey-60'); }
+			.token.punctuation { color: oColorsGetPaletteColor('grey-70'); }
+			.token.string { color: oColorsGetPaletteColor('oxford-jade-60'); }
 		}
 
 		code,
 		var {
 			background: oColorsGetPaletteColor('grey-5');
-			color: oColorsGetPaletteColor('grey-70');
+			color: oColorsGetPaletteColor('black');
 			font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 			font-size: 14px;
 			line-height: 1.5;
@@ -32,7 +36,7 @@
 		}
 
 		var {
-			color: oColorsGetPaletteColor('oxford-sky-80');
+			color: oColorsGetPaletteColor('teal');
 			font-weight: 600;
 		}
 	}

--- a/src/scss/languages/main.scss
+++ b/src/scss/languages/main.scss
@@ -6,7 +6,7 @@
 @import 'scss';
 @import 'diff';
 
-@mixin oSyntaxHighlightBase() {
+@mixin _oSyntaxHighlightBase() {
 	[data-o-component='o-syntax-highlight'] {
 		pre {
 			background: oColorsGetPaletteColor('grey-5');
@@ -36,15 +36,4 @@
 			font-weight: 600;
 		}
 	}
-}
-
-@mixin oSyntaxHighlightAll() {
-	@include oSyntaxHighlightBase();
-	@include oSyntaxHighlightBASH();
-	@include oSyntaxHighlightCSS();
-	@include oSyntaxHighlightHTML();
-	@include oSyntaxHighlightJS();
-	@include oSyntaxHighlightJSON();
-	@include oSyntaxHighlightSCSS();
-	@include oSyntaxHighlightDIFF();
 }


### PR DESCRIPTION
🎉  MY LAST `O-MAJOR` 😭

We had discussed using CSS colors instead of the palette, but we do have access to the palette and a lot of effort has gone in to making sure it is accessible, so I've decided to keep it that way for now.

Apart from introducing the primary mixin, I've removed the mixed colour that uses `sky` because it is the only colour that the internal colour palette doesn't currently support.