### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -1,13 +1,12 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
 import SyntaxHighlight from '../src/js/syntax-highlight';
-import assert from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import fixtures from './helpers/fixtures';
 
 const flatten = string => string.replace(/\s/g, '');
 
-sinon.assert.expose(assert, {
+sinon.assert.expose(proclaim, {
 	includeFail: false,
 	prefix: ''
 });
@@ -34,17 +33,17 @@ describe("Syntax Highlight", () => {
 		});
 
 		it('stores `syntaxEl` in a syntaxElement property', () => {
-			assert.strictEqual(highlight.syntaxElement, syntaxEl);
+			proclaim.strictEqual(highlight.syntaxElement, syntaxEl);
 		});
 
 		it('throws an error if the language is not supported by prism', () => {
 			const error = "*** o-syntax-highlight error:\nThe language bob is not supported. Please contact Origami if you would like to have it added.\n***";
-			assert.throws(() => { new SyntaxHighlight('new bob language', {language: 'bob'}); }, error);
+			proclaim.throws(() => { new SyntaxHighlight('new bob language', {language: 'bob'}); }, error);
 		});
 
 		describe('with an HTML element', () => {
 			it('fetches the language to highlight from the element class', () => {
-				assert.strictEqual(highlight.opts.language, 'json');
+				proclaim.strictEqual(highlight.opts.language, 'json');
 			});
 
 			it('throws an error if the <code> tag does not have a class', () => {
@@ -52,11 +51,11 @@ describe("Syntax Highlight", () => {
 				testArea.innerHTML = fixtures.classlessJSON;
 				syntaxEl = document.querySelector('[data-o-component=o-syntax-highlight]');
 
-				assert.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
+				proclaim.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
 			});
 
 			it('tokenises string within a <code> tag', () => {
-				assert.strictEqual(flatten(syntaxEl.innerHTML), flatten(fixtures.tokenisedJSON));
+				proclaim.strictEqual(flatten(syntaxEl.innerHTML), flatten(fixtures.tokenisedJSON));
 			});
 
 			it('throws an error if code block is not built semantically', () => {
@@ -64,19 +63,19 @@ describe("Syntax Highlight", () => {
 				testArea.innerHTML = fixtures.unsemanticJSON;
 				syntaxEl = document.querySelector('[data-o-component=o-syntax-highlight]');
 
-				assert.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
+				proclaim.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
 			});
 		});
 
 		describe('with a string', () => {
 			it('fetches the language to highlight from the options object', () => {
 				highlight = new SyntaxHighlight('<div>HTML</div>', { language: 'html'});
-				assert.strictEqual(highlight.opts.language, 'html');
+				proclaim.strictEqual(highlight.opts.language, 'html');
 			});
 
 			it('throws an error if a language is not provided in the options', () => {
 				const error = "*** o-syntax-highlight error:\nA language must be defined in the options object\n***";
-				assert.throws(() => { new SyntaxHighlight('a string of code'); }, error);
+				proclaim.throws(() => { new SyntaxHighlight('a string of code'); }, error);
 			});
 		});
 	});


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.