### PR TITLE
Error less, warn more. E.g. when a code block has no language defined.

### DIFF
--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -53,7 +53,7 @@ describe("Syntax Highlight", () => {
 
 				const warningSpy = sinon.spy(console, 'warn');
 				new SyntaxHighlight(syntaxEl);
-				assert(warningSpy.withArgs(warning, sinon.match.any).calledOnce);
+				proclaim.isTrue(warningSpy.withArgs(warning, sinon.match.any).calledOnce);
 				warningSpy.restore();
 			});
 

--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -46,24 +46,25 @@ describe("Syntax Highlight", () => {
 				proclaim.strictEqual(highlight.opts.language, 'json');
 			});
 
-			it('throws an error if the <code> tag does not have a class', () => {
-				const error = `*** o-syntax-highlight error:\nIn order to highlight a codeblock, the '<code>' requires a specific class to define a language. E.g. class="o-syntax-highlight--html" or class="o-syntax-highlight--js"\n***`;
+			it('logs a warning if the <code> tag does not have a class', () => {
+				const warning = `In order to highlight a codeblock, the '<code>' requires a specific class to define a language. E.g. class="o-syntax-highlight--html" or class="o-syntax-highlight--js"`;
 				testArea.innerHTML = fixtures.classlessJSON;
 				syntaxEl = document.querySelector('[data-o-component=o-syntax-highlight]');
 
-				proclaim.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
+				const warningSpy = sinon.spy(console, 'warn');
+				new SyntaxHighlight(syntaxEl);
+				assert(warningSpy.withArgs(warning, sinon.match.any).calledOnce);
+				warningSpy.restore();
 			});
 
 			it('tokenises string within a <code> tag', () => {
 				proclaim.strictEqual(flatten(syntaxEl.innerHTML), flatten(fixtures.tokenisedJSON));
 			});
 
-			it('throws an error if code block is not built semantically', () => {
-				const error = "*** o-syntax-highlight error:\nNo '<code>' tag found. In order to highlight a codeblock semantically, a '<pre>' tag must wrap a '<code>' tag.\n***";
+			it('does not throw an error if a pre tag is found with no code block', () => {
 				testArea.innerHTML = fixtures.unsemanticJSON;
 				syntaxEl = document.querySelector('[data-o-component=o-syntax-highlight]');
-
-				proclaim.throws(() => { new SyntaxHighlight(syntaxEl); }, error);
+				proclaim.doesNotThrow(() => { new SyntaxHighlight(syntaxEl); });
 			});
 		});
 


### PR DESCRIPTION
According to the README o-syntax-highlight may be used as a wrapper,
which will highlight all code blocks within. E.g.

```html
<div class="demo" data-o-component='o-syntax-highlight'>
	<div class="example">
		<p></p>
		<p></p>
	</div>

	<pre>
		<code class="o-syntax-highlight--json">
<!-- everything in this element will be highlighted, including this comment! --></code>
	</pre>

	<button type="button" name="button">Button</button>
</div>
```

However an error is thrown if:
1. A `pre` tag is found within a child `code` block. That is
frustrating as the container cannot contain any `pre` elements.
So instead of error o-syntax-highlight should assume and `pre`
tag without a `code` tag is not code, and ignore it.
2. A `code` tag is found without a class to indicate the language
to highlight, e.g. `o-syntax-highlight--js`. This means one code
block with a missing language prevents any other code block
from highlighting. Instead of error o-syntax-highlight should
provide a warning.