### PR TITLE
Do not error when a code element has another class.

### DIFF
--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -52,10 +52,10 @@ class SyntaxHighlight {
 	* @param {HTMLElement} - The element with a language-relevant class name
 	* @return {String | Null} - The language name e.g. `js` or null if not defined.
 	*/
-	_getLanguage (element) {
-		const className = element.className;
+	_getLanguage(element) {
+		const highlightClassName = [...element.classList].find(c => c.includes('o-syntax-highlight--'));
 
-		if (!className.includes('o-syntax-highlight--')) {
+		if (!highlightClassName) {
 			console.warn(
 				`In order to highlight a codeblock, the '<code>' ` +
 				`requires a specific class to define a language. E.g. ` +
@@ -64,7 +64,7 @@ class SyntaxHighlight {
 			return null;
 		}
 
-		this.opts.language = className.replace('o-syntax-highlight--', '');
+		this.opts.language = highlightClassName.replace('o-syntax-highlight--', '');
 
 		this._checkLanguage();
 

--- a/src/js/syntax-highlight.js
+++ b/src/js/syntax-highlight.js
@@ -53,7 +53,8 @@ class SyntaxHighlight {
 	* @return {String | Null} - The language name e.g. `js` or null if not defined.
 	*/
 	_getLanguage(element) {
-		const highlightClassName = [...element.classList].find(c => c.includes('o-syntax-highlight--'));
+		const highlightClassNames = [...element.classList].filter(c => c.includes('o-syntax-highlight--'));
+		const highlightClassName = highlightClassNames ? highlightClassNames[0]: null;
 
 		if (!highlightClassName) {
 			console.warn(

--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -46,6 +46,20 @@ describe("Syntax Highlight", () => {
 				proclaim.strictEqual(highlight.opts.language, 'json');
 			});
 
+			it('fetches the language to highlight from the element with multiple classes', () => {
+				testArea.innerHTML = fixtures.classlessJSON;
+				syntaxEl = document.querySelector('[data-o-component=o-syntax-highlight]');
+				// Set classes. One with the expected language another random class for the test
+				// with a decoy language.
+				const expectedLanguage = 'json';
+				document.querySelectorAll('code').forEach(el => {
+					el.className = `some-other-class--html o-syntax-highlight--${expectedLanguage}`;
+				});
+				new SyntaxHighlight(syntaxEl);
+				// Check the expected language was found.
+				proclaim.strictEqual(highlight.opts.language, expectedLanguage);
+			});
+
 			it('logs a warning if the <code> tag does not have a class', () => {
 				const warning = `In order to highlight a codeblock, the '<code>' requires a specific class to define a language. E.g. class="o-syntax-highlight--html" or class="o-syntax-highlight--js"`;
 				testArea.innerHTML = fixtures.classlessJSON;


### PR DESCRIPTION
o-syntax-highlight gets the language to format code blocks as from
the class `o-syntax-highlight--*`. Howver if there is any other class
on the codeblock an error is thrown. This commit fixes that.

(At the moment this is causing the registry to error, and so the demo 
iframes are not expanding e.g. https://registry.origami.ft.com/components/o-forms@8.3.6/)